### PR TITLE
Update instructions.md

### DIFF
--- a/instructions.md
+++ b/instructions.md
@@ -1,8 +1,8 @@
-# How to submit CNTI Certification results
+# How to submit CNTi Certification results
 
 ## The tests
 
-There are [57 tests](docs/CNFCertification-1.0-beta.md) included in the CNF Certification v1.0-beta. These tests are classified as Essential, Normal, or Bonus. They are also organized into 7 categories: 
+There are [## tests- TBD: ## TO BE UPDATED](docs/CNTiCertification-2.0-beta.md) included in the CNTi Certification v2.0-beta. These tests are classified as Essential, Normal, or Bonus. They are also organized into 7 categories: 
 - Compatibility, Installability, and Upgradability
 - Configuration
 - Security
@@ -24,13 +24,13 @@ There are [57 tests](docs/CNFCertification-1.0-beta.md) included in the CNF Cert
 
 If you do not have a K8s cluster running, you can deploy your own cluster with [various tools](https://kubernetes.io/docs/setup/) or use a [public cloud or turnkey solution](https://kubernetes.io/docs/setup/production-environment/turnkey-solutions/)
 
-Kind is one option tested and supported by the CNTI Test Catalog team.  Follow the [kind install](https://github.com/cnti-testcatalog/testsuite/blob/main/KIND-INSTALL.md) instructions to setup a cluster in [kind](https://kind.sigs.k8s.io/)
+Kind is one option tested and supported by the CNTi Test Catalog.  Follow the [kind install](https://github.com/cnti-testcatalog/testsuite/blob/main/KIND-INSTALL.md) instructions to setup a cluster in [kind](https://kind.sigs.k8s.io/)
 
 
 ## Running
-The standard tool for running these tests is the [CNTI Test Catalog](https://github.com/cnti-testcatalog/testsuite). 
+The standard tool for running these tests is the [CNTi Test Catalog](https://github.com/cnti-testcatalog/testsuite). 
 
-1. Download the [certification binary release](https://github.com/cnti-testcatalog/testsuite/releases/tag/v0.29.1) of the test suite
+1. Download the [certification binary release](https://github.com/cnti-testcatalog/testsuite/releases/tag/v1.0.0) of the test suite
 1. Run setup to prepare the cnf-testsuite: `cnf-testsuite setup`
 3. Create a configuration file for testing your CNF
     1. Review the [CNF_TESTSUITE_YML_USAGE.md](https://github.com/cnti-testcatalog/testsuite/blob/main/CNF_TESTSUITE_YML_USAGE.md) document on formatting and other requirements.
@@ -55,12 +55,12 @@ Prepare a Pull Request (PR) to [https://github.com/lfn-cnti/certification](https
 
 Here are [directions](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork) to prepare a pull request from a fork.
 
-The PR title should look like this: `CNTI Certification results for vX.Y/DIR`
+The PR title should look like this: `CNTi Certification results for vX.Y/DIR`
 
-In the PR title above, the `X.Y` refers to the CNTI Certification major and minor version, and `DIR` is a short subdirectory name to hold the results for your product.  Examples
+In the PR title above, the `X.Y` refers to the CNTi Certification major and minor version, and `DIR` is a short subdirectory name to hold the results for your product.  Examples
 
-- `CNTI Certification results for v1.0/mychargingapp`
-- `CNTI Certification results for v1.2/fancyfirewall`
+- `CNTi Certification results for v1.0/mychargingapp`
+- `CNTi Certification results for v1.2/fancyfirewall`
 
 
 ### Contents of the PR
@@ -72,7 +72,7 @@ Your PR should have the subdirecty (as mentioned above) with the following files
 - vX.Y/DIR/README.md: A script or human-readable description of how to reproduce
 your results
 - vX.Y/DIR/cnf-testsuite.yml test suite configuration for your CNF
-- vX.Y/DIR/cnf-testsuite-results-YYYY-MMDD-HHMMSS-NNN.yml log output (from CNF Test Suite)
+- vX.Y/DIR/cnf-testsuite-results-YYYY-MMDD-HHMMSS-NNN.yml log output (from CNTi Test Suite)
 - vX.Y/DIR/PRODUCT.yaml: See below
 <!-- - vX.Y/DIR/test.log: Test log output (from CNF Certification).-->
 
@@ -112,6 +112,4 @@ description: "The Yoyodyne Turbo DHCP-Proxy is a superb DHCP proxy
 A reviewer will shortly comment on and/or accept your pull request, following [this process](https://github.com/lfn-cnti/certification/blob/main/reviewing.md). If you don't see a response within 5 business days, please send an email to lfn-cnti@lfnetworking.org.
 
 ## Issues
-If you have problems self-certifying that you feel is due to an issue with the CNTI Certification program (and not just your own implementation), you can file an issue in this repository. Questions and comments can also be sent via email to lfn-cnti@lfnetworking.org.
-
-
+If you have problems self-certifying that you feel is due to an issue with the CNTi Certification program (and not just your own implementation), you can file an issue in this repository. Questions and comments can also be sent via email to lfn-cnti@lfnetworking.org.


### PR DESCRIPTION
Refs #74 
- Changed CNTI to CNTi (lowercase i) 
- Updated "57 tests" URL From v1.0-beta to v2.0-beta
- Updated "certification binary release" link to upcoming https://github.com/cnti-testcatalog/testsuite/releases/tag/v1.0.0


To do: 
- tally total number of tests and update "There are ## tests included in the CNTi Certification v2.0-beta."
